### PR TITLE
Add PrimitiveRepr trait.

### DIFF
--- a/repr-trait-derive/src/lib.rs
+++ b/repr-trait-derive/src/lib.rs
@@ -4,7 +4,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, AttrStyle, Attribute, DeriveInput, Path};
+use syn::{parse_macro_input, AttrStyle, Attribute, DeriveInput, Ident, Path};
 
 macro_rules! repr_derive {
     ($tr:ident : $fn:ident($inner:expr) ) => {
@@ -28,6 +28,79 @@ macro_rules! repr_derive {
 repr_derive!(Packed: repr_packed("packed"));
 repr_derive!(Transparent: repr_transparent("transparent"));
 repr_derive!(C: repr_c("C"));
+
+#[proc_macro_derive(PrimitiveRepr)]
+pub fn primitive_repr(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let data_enum = match &input.data {
+        syn::Data::Struct(_) => panic!("Can't derive PrimitiveRepr on a struct"),
+        syn::Data::Enum(data_enum) => data_enum,
+        syn::Data::Union(_) => panic!("Can't derive PrimitiveRepr on an union"),
+    };
+
+    if data_enum.variants.is_empty() {
+        panic!("Can't derive PrimitiveRepr on a zero variant enum");
+    }
+
+    if let Some(type_name) = find_repr_type(&input.attrs) {
+        let ident = input.ident;
+        let repr_ident = Ident::new(&type_name, ident.span());
+        quote!(
+            unsafe impl PrimitiveRepr for #ident {
+                type Type = #repr_ident;
+            }
+        )
+        .into()
+    } else {
+        panic!("Can't derive PrimitiveRepr on a struct without repr(u*) or repr(i*)");
+    }
+}
+
+fn find_repr_type(attributes: &[Attribute]) -> Option<String> {
+    for attr in attributes {
+        // If the style isn't outer, reject it
+        if !matches!(attr.style, AttrStyle::Outer) {
+            continue;
+        }
+        // If the path doesn't match, reject it
+        if let Path {
+            leading_colon: None,
+            ref segments,
+        } = attr.path
+        {
+            // If there's more than one, reject it
+            if segments.len() != 1 {
+                continue;
+            }
+
+            let seg = segments.first().unwrap();
+
+            // If there are arguments, reject it
+            if !seg.arguments.is_empty() {
+                continue;
+            }
+
+            // If the ident isn't "repr", reject it
+            if seg.ident != "repr" {
+                continue;
+            }
+        } else {
+            // If we don't match, reject if
+            continue;
+        }
+
+        let mut repr_type_name = format!("{}", attr.tokens);
+
+        // Ensure repr is (u*) or (i*) and return what's inside.
+        if (repr_type_name.starts_with("(u") || repr_type_name.starts_with("(i"))
+            && repr_type_name.ends_with(')')
+        {
+            repr_type_name = repr_type_name[1..repr_type_name.len() - 1].to_string();
+            return Some(repr_type_name);
+        }
+    }
+    None
+}
 
 fn has_repr(attrs: &[Attribute], repr: &str) -> bool {
     for attr in attrs {
@@ -55,7 +128,7 @@ fn has_repr(attrs: &[Attribute], repr: &str) -> bool {
             }
 
             // If the ident isn't "repr", reject it
-            if seg.ident.to_string() != "repr" {
+            if seg.ident != "repr" {
                 continue;
             }
         } else {
@@ -64,6 +137,7 @@ fn has_repr(attrs: &[Attribute], repr: &str) -> bool {
         }
 
         // If it doesn't match, reject it
+
         if format!("{}", attr.tokens) != format!("({})", repr) {
             continue;
         }

--- a/repr-trait/test/primitive_repr_fail.rs
+++ b/repr-trait/test/primitive_repr_fail.rs
@@ -1,0 +1,10 @@
+#[derive(repr_trait::PrimitiveRepr)]
+enum Enum {
+    A,
+    B,
+    C,
+}
+
+fn main() {
+
+}

--- a/repr-trait/test/primitive_repr_fail.stderr
+++ b/repr-trait/test/primitive_repr_fail.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> test/primitive_repr_fail.rs:1:10
+  |
+1 | #[derive(repr_trait::PrimitiveRepr)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Can't derive PrimitiveRepr on a struct without repr(u*) or repr(i*)

--- a/repr-trait/test/zero_variants_fail.rs
+++ b/repr-trait/test/zero_variants_fail.rs
@@ -1,0 +1,7 @@
+#[derive(repr_trait::PrimitiveRepr)]
+enum ZeroVariants {
+}
+
+fn main() {
+
+}

--- a/repr-trait/test/zero_variants_fail.stderr
+++ b/repr-trait/test/zero_variants_fail.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> test/zero_variants_fail.rs:1:10
+  |
+1 | #[derive(repr_trait::PrimitiveRepr)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Can't derive PrimitiveRepr on a zero variant enum

--- a/repr-trait/tests/discriminant.rs
+++ b/repr-trait/tests/discriminant.rs
@@ -1,0 +1,42 @@
+use repr_trait::{self, PrimitiveRepr};
+
+#[derive(PrimitiveRepr)]
+#[repr(i64)]
+enum SimpleEnum {
+    A,
+    B,
+    C,
+}
+
+#[derive(PrimitiveRepr)]
+#[repr(usize)]
+enum ComplexEnum {
+    Unit,
+    Tuple(u64) = 154,
+    Struct { _a: bool },
+}
+
+fn discriminant_value<T>(value: &T) -> T::Type
+where
+    T: PrimitiveRepr,
+    T::Type: Copy,
+{
+    *repr_trait::discriminant(value)
+}
+
+#[test]
+fn can_access_discriminant_of_complex_enum() {
+    assert_eq!(discriminant_value(&ComplexEnum::Unit), 0usize);
+    assert_eq!(discriminant_value(&ComplexEnum::Tuple(42)), 154usize);
+    assert_eq!(
+        discriminant_value(&ComplexEnum::Struct { _a: true }),
+        155usize
+    );
+}
+
+#[test]
+fn can_access_discriminant_of_simple_enum() {
+    assert_eq!(discriminant_value(&SimpleEnum::A), 0i64);
+    assert_eq!(discriminant_value(&SimpleEnum::B), 1i64);
+    assert_eq!(discriminant_value(&SimpleEnum::C), 2i64);
+}


### PR DESCRIPTION
This PR adds an additional trait, and a derive macro for automatically implementing a `PrimitiveRepr` trait with an associated type `Type =T` that represents the contents of repr attribute: `#[repr(T)]`.

This is useful in certain scenarios where you want to access the discriminant value in a safe manner (i.e. as opposed to `mem::discriminant`), and also ensure that type matches the contents of `repr(T)` attribute for safety.

# Example

```rust
const MSG_TYPE_1: u16 = 0x10;
const MSG_TYPE_2: u16 = 0x11;

#[derive(PrimitiveRepr)]
enum Msg {
  Type1 = MSG_TYPE_1,
  Type2 { value: String } = MSG_TYPE_2,
}

let msg = Msg::Type2 { value: "Foo".to_string() };
assert_eq!(&repr_trait::discriminant(&msg), MSG_TYPE_2);
```